### PR TITLE
Fix incorrect key in ConsumerSupervisor test

### DIFF
--- a/test/consumer_supervisor_test.exs
+++ b/test/consumer_supervisor_test.exs
@@ -31,8 +31,8 @@ defmodule Rabbit.ConsumerSupervisorTest do
 
     @impl Rabbit.ConsumerSupervisor
     def handle_setup(state) do
-      AMQP.Queue.declare(state.chan, state.queue, auto_delete: true)
-      AMQP.Queue.purge(state.chan, state.queue)
+      AMQP.Queue.declare(state.channel, state.queue, auto_delete: true)
+      AMQP.Queue.purge(state.channel, state.queue)
 
       :ok
     end


### PR DESCRIPTION
I noticed the test was failing because b20d2fff94668f85cbfc3e9dd91b63808b8b6d4d didn't update `chan` to `channel`.