### PR TITLE
Remove Connection.Server.publish no-op

### DIFF
--- a/lib/rabbit/connection/server.ex
+++ b/lib/rabbit/connection/server.ex
@@ -256,9 +256,7 @@ defmodule Rabbit.Connection.Server do
   end
 
   defp publish(subscribers, message) do
-    for pid <- subscribers do
-      if Process.alive?(pid), do: send(pid, message)
-    end
+    for pid <- subscribers, do: send(pid, message)
 
     :ok
   end


### PR DESCRIPTION
I spotted this usage of `Process.alive()` while reading the `Connection` code and I think it can be safely removed as `send/2` will never fail when given a valid `pid`, even if the process is dead. If `pid` is not the right type, they will both crash in the same way.